### PR TITLE
fix: resolve GAS syntax error - move methods inside ErrorHandler class

### DIFF
--- a/server/ErrorHandler.js
+++ b/server/ErrorHandler.js
@@ -465,8 +465,7 @@ class ErrorHandler {
       .replace(/'/g, '&#x27;')
       .replace(/\//g, '&#x2F;');
   }
-}
-
+  
   /**
    * Check if current user is admin for security purposes
    * @returns {boolean} True if user is admin


### PR DESCRIPTION
Fixed "Unexpected identifier 'isAdminUser'" error by moving static methods inside the ErrorHandler class definition.

This resolves the clasp push syntax error preventing deployment to Google Apps Script.

Generated with [Claude Code](https://claude.ai/code)