### PR TITLE
fix: resolve regex syntax error preventing Google Apps Script deployment

### DIFF
--- a/server/SecurityConfig.js
+++ b/server/SecurityConfig.js
@@ -51,7 +51,7 @@ class SecurityConfig {
       allowedFileTypes: ['pdf', 'txt', 'csv', 'xlsx'],
       maxFileSize: 10 * 1024 * 1024, // 10MB
       sqlInjectionPatterns: [
-        /('|(\\';)|(;)|(--)|(\/\*)|(\*\/)|(\bselect\b)|(\binsert\b)|(\bupdate\b)|(\bdelete\b)|(\bdrop\b)|(\bcreate\b)|(\balter\b)|(\bexec\b)|(\bunion\b)|(\bscript\b)/i
+        /('|\\';|;|--|\/\*|\*\/|\bselect\b|\binsert\b|\bupdate\b|\bdelete\b|\bdrop\b|\bcreate\b|\balter\b|\bexec\b|\bunion\b|\bscript\b)/i
       ],
       xssPatterns: [
         /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi,


### PR DESCRIPTION
Fixed "Unterminated group" error in SecurityConfig.js line 54 by removing improper parenthetical grouping and correcting the SQL injection pattern regex. This resolves the clasp push syntax error that was preventing deployment to GAS.

Generated with [Claude Code](https://claude.ai/code)